### PR TITLE
Forgot to cast a reference to an array for push.

### DIFF
--- a/t/start_stop.t
+++ b/t/start_stop.t
@@ -189,7 +189,7 @@ is_deeply( [ Alien::ActiveMQ::Mock->get_installed_versions() ],
     my $_output_data = [];
     local *Alien::ActiveMQ::_output = sub {
         my $class = shift;
-        push $_output_data, @_;
+        push @{$_output_data}, @_;
     };
 
     my $amq = Alien::ActiveMQ->new;


### PR DESCRIPTION
Didn't work right in older Perls.  Just a test problem, but easy to
fix.
