### PR TITLE
Remove .exists from MANIFEST.SKIP

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,7 +1,6 @@
 ^TODO$
 ^Alien-ActiveMQ-
 
-\.exists$
 \.perlcriticrc$
 
 # Avoid version control files.


### PR DESCRIPTION
Removing .exists means 'share' is not included.  It's needed, so make sure
it is properly used.
