### PR TITLE
Use correct test version number.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,4 @@
-0.00005_01
+0.00004_01
   * Advanced version of ActiveMQ to current release version.
   * Fixed script to be more reliable, easier to use.
   * Changed script to check the tarball or the URI for version number.

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-This archive contains the distribution Alien-ActiveMQ, version 0.0005_01:
+This archive contains the distribution Alien-ActiveMQ, version 0.0004_01:
 
     Manages installs of versions of Apache ActiveMQ, and provides a standard
     way to start an MQ server from Perl.

--- a/lib/Alien/ActiveMQ.pm
+++ b/lib/Alien/ActiveMQ.pm
@@ -11,7 +11,7 @@ use Net::Stomp;
 use Sort::Versions;
 use namespace::autoclean;
 
-our $VERSION = '0.00005_01';
+our $VERSION = '0.00004_01';
 
 # Note: Many of the methods in this class need to be usable as class methods.
 # This means you can't use Moose attributes, because they try and store data

--- a/script/install-activemq
+++ b/script/install-activemq
@@ -16,7 +16,7 @@ use Const::Fast;
 
 with 'MooseX::Getopt';
 
-our $VERSION = '0.00005_01';
+our $VERSION = '0.00004_01';
 
 const my $DEFAULT_ACTIVEMQ_VERSION => '5.10.0';
 


### PR DESCRIPTION
Unless I want to miss version 0005 entirely, I should make this a test
release of v4.  Closer reading of the docs clarified this.
